### PR TITLE
Add ControllerService to angular-mocks

### DIFF
--- a/angularjs/angular-mocks-tests.ts
+++ b/angularjs/angular-mocks-tests.ts
@@ -88,6 +88,15 @@ logCall = logService.warn;
 logs = logCall.logs;
 
 ///////////////////////////////////////
+// ControllerService mock
+///////////////////////////////////////
+var $controller: ng.IControllerService;
+$controller(class TestController {}, {}, {myBinding: 'works!'});
+$controller(function TestController() {}, {someLocal: 42}, {myBinding: 'works!'});
+$controller('TestController', {}, {myBinding: 'works!'});
+
+
+///////////////////////////////////////
 // IComponentControllerService
 ///////////////////////////////////////
 var $componentController: ng.IComponentControllerService;

--- a/angularjs/angular-mocks.d.ts
+++ b/angularjs/angular-mocks.d.ts
@@ -98,6 +98,18 @@ declare namespace angular {
     }
 
     ///////////////////////////////////////////////////////////////////////////
+    // ControllerService mock
+    // see https://docs.angularjs.org/api/ngMock/service/$controller
+    // This interface extends http://docs.angularjs.org/api/ng.$controller
+    ///////////////////////////////////////////////////////////////////////////
+    interface IControllerService {
+      // Although the documentation doesn't state this, locals are optional
+      <T>(controllerConstructor: new (...args: any[]) => T, locals?: any, bindings?: any): T;
+      <T>(controllerConstructor: Function, locals?: any, bindings?: any): T;
+      <T>(controllerName: string, locals?: any, bindings?: any): T;
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
     // ComponentControllerService
     // see https://docs.angularjs.org/api/ngMock/service/$componentController
     ///////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.

The definition in angular.d.ts changed that used to included this definition.
Needed because of 69d2fb9